### PR TITLE
Add Scalekit to Auth and Identity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Reflex's own website was built using Reflex! See [code on GitHub.](https://githu
 - [Neon](https://neon.tech) - Serverless Postgres database service
 - [Clerk](https://clerk.com/) ([auth library](https://kroo.github.io/reflex-clerk/)) - Authentication and user management
 - [Firebase](https://youtu.be/JRGyvjjWb00?list=PLDHA4931gtc7wHBDGQOYlmcpZm7qyici7) - Backend services for apps
+- [Scalekit](https://www.scalekit.com) - Add enterprise SSO (SAML, OIDC) and SCIM provisioning on top of existing auth systems like Auth0, Firebase, or Cognito without rewrites
 
 ## 🔗 Checkout/Social media links
 


### PR DESCRIPTION
Scalekit is a developer-first platform that helps B2B SaaS teams support enterprise authentication requirements including SAML/OIDC-based SSO, SCIM provisioning, and customizable login flows — on top of their existing auth stack.

It’s designed for developers who want to keep their current setup (Firebase Auth, Auth0, Cognito, etc.) but need to support enterprise customers without rebuilding everything.

Docs: https://docs.scalekit.com  
Blog: https://scalekit.com/blog

Let me know if this fits the criteria or should be reworded. Thanks for maintaining this awesome list!